### PR TITLE
updated firestore indexes and fixed issue where isAdmin should be isMod

### DIFF
--- a/web_app/firestore.indexes.json
+++ b/web_app/firestore.indexes.json
@@ -1,44 +1,880 @@
 {
   "indexes": [
     {
-        "collectionId": "movies",
+      "collectionId": "movies",
         "fields": [
           { "fieldPath": "genres.action", "mode": "ASCENDING"},
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"}
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
           { "fieldPath": "genres.action", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "DESCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" } 
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
-          { "fieldPath": "genres.adventure", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.animation", "mode": "ASCENDING"},
-          { "fieldPath": "genres.animation", "mode": "DESCENDING"},
-          { "fieldPath": "genres.crime", "mode": "ASCENDING"},
-          { "fieldPath": "genres.crime", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.animation", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.comedy", "mode": "ASCENDING"},
-          { "fieldPath": "genres.comedy", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.comedy", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
+          { "fieldPath": "genres.children", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.children", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.documentary", "mode": "ASCENDING"},
-          { "fieldPath": "genres.documentary", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.documentary", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.drama", "mode": "ASCENDING"},
-          { "fieldPath": "genres.drama", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.drama", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.family", "mode": "ASCENDING"},
-          { "fieldPath": "genres.family", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.family", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.fantasy", "mode": "ASCENDING"},
-          { "fieldPath": "genres.fantasy", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.fantasy", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.history", "mode": "ASCENDING"},
-          { "fieldPath": "genres.history", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.history", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.horror", "mode": "ASCENDING"},
-          { "fieldPath": "genres.horror", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.horror", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.music", "mode": "ASCENDING"},
-          { "fieldPath": "genres.music", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.music", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.mystery", "mode": "ASCENDING"},
-          { "fieldPath": "genres.mystery", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.mystery", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.romance", "mode": "ASCENDING"},
-          { "fieldPath": "genres.romance", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.romance", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.scifi", "mode": "ASCENDING"},
-          { "fieldPath": "genres.scifi", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.scifi", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.thriller", "mode": "ASCENDING"},
-          { "fieldPath": "genres.thriller", "mode": "DESCENDING"},
-          { "fieldPath": "genres.war", "mode": "ASCENDING"},
-          { "fieldPath": "genres.war", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.thriller", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "tmdb", "mode": "ASCENDING" },
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
+          { "fieldPath": "genres.war", "mode": "ASCENDING"}
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.war", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING"},
           { "fieldPath": "genres.western", "mode": "ASCENDING"},
-          { "fieldPath": "genres.western", "mode": "DESCENDING"}
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.action", "mode": "ASCENDING" },
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING" },
+          { "fieldPath": "genres.western", "mode": "ASCENDING" },
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "DESCENDING"},
+          { "fieldPath": "tmdb", "mode": "DESCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.children", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.comedy", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.crime", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.documentary", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.drama", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.family", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.fantasy", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.history", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.family", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.fantasy", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.history", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.horror", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.music", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.mystery", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.romance", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.scifi", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.thriller", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.war", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.western", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.children", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.crime", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.comedy", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.documentary", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.drama", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.family", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.fantasy", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.history", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.horror", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.music", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.mystery", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.romance", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.scifi", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.thriller", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.war", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.adventure", "mode": "ASCENDING"},
+          { "fieldPath": "genres.western", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.children", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.comedy", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.crime", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.documentary", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.documentary", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.drama", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.family", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.fantasy", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.history", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.horror", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.music", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.mystery", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.romance", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.scifi", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.thriller", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.war", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.animation", "mode": "ASCENDING"},
+          { "fieldPath": "genres.western", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.children", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.crime", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.comedy", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.documentary", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.drama", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.family", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.fantasy", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.history", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.horror", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.music", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },    
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.mystery", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.romance", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.scifi", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.thriller", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.war", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
+        ]
+    },
+    {
+    "collectionId": "movies",
+        "fields": [
+          { "fieldPath": "genres.western", "mode": "ASCENDING"},
+          { "fieldPath": "tmdb", "mode": "ASCENDING" }
         ]
     }
   ]

--- a/web_app/src/components/Toolbar/index.ts
+++ b/web_app/src/components/Toolbar/index.ts
@@ -84,7 +84,7 @@ export default class Toolbar extends Vue {
   accidentally clicking in the wrong place */
   isGenreClicked = false;
   isHidden = false;
-  isAdmin = false;
+  isMod = false;
   isAdminClicked = false;
   isMyMoviesClicked = false;
   loginTitle = "Log In";
@@ -172,7 +172,7 @@ export default class Toolbar extends Vue {
       if (!user) {
         await fst.auth.signInAnonymously();
         _this.anonUID = fst.auth.currentUser.uid;
-        _this.isAdmin = false;
+        _this.isMod = false;
         _this.$emit("login");
       } else {
         // Otherwise render out the info
@@ -186,7 +186,7 @@ export default class Toolbar extends Vue {
   async displayUserInfo() {
     if (!this.fst.auth.currentUser.isAnonymous) {
       this.loginTitle = "Log Out";
-      this.isAdmin = await this.dm.checkIsMod();
+      this.isMod = await this.dm.checkIsMod();
     } else {
       this.loginTitle = "Log In";
     }
@@ -203,7 +203,7 @@ export default class Toolbar extends Vue {
       .then(async function(result) {
         // If we succeed, we've now modified our user (no longer anonymous)
         // so we re-render our info
-        _this.isAdmin = await _this.dm.checkIsMod();
+        _this.isMod = await _this.dm.checkIsMod();
         _this.loginTitle = "Log Out";
       })
       .catch(async function(error) {
@@ -213,7 +213,7 @@ export default class Toolbar extends Vue {
         await fst.auth.signInWithCredential(error.credential);
         _this.uid = fst.auth.currentUser.uid;
         _this.writeMoviesToNewUser(uid, movies);
-        _this.isAdmin = await _this.dm.checkIsMod();
+        _this.isMod = await _this.dm.checkIsMod();
         _this.loginTitle = "Log Out";
       });
   }
@@ -222,7 +222,7 @@ export default class Toolbar extends Vue {
     this.fst = await FirebaseSingleton.GetInstance();
     await this.fst.auth.signOut();
     this.loginTitle = "Log In";
-    this.isAdmin = false;
+    this.isMod = false;
   }
 }
 


### PR DESCRIPTION
I had accidentally replaced the indexes with one long index. Went back to how they should be to enable queries of genres. Also changed isAdmin to isMod in Toolbar so view will update to reveal Moderator tab when claim is enabled.